### PR TITLE
feat: enabled invite_accepter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ This module creates the "member" side of Guardduty, with the assumption that the
 | enabled | The boolean flag whether this module is enabled or not. No resources are created when set to false. | `bool` | `true` | no |
 | lambda\_name | Name of the Lambda Function | `any` | n/a | yes |
 | sns\_email\_arn | SNS Topic ARN | `string` | `""` | no |
+| enable\_detector | Enable GuardDuty Member Detector | `bool` | `true` | no |
+| create\_invite\_accepter | Create GuardDuty Member Invite Accepter. Not needed if already setup as part of an organization | `bool` | `true` | no |
+| member\_detector\_id | GuardDuty Detector ID for member account. Only needed if enable_detector is false. Used for targeting any previously enable detector | `string` | `""` | no |
 
 ## Outputs
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -39,6 +39,6 @@ variable "create_invite_accepter" {
 }
 
 variable "member_detector_id" {
-  description = "GuardDuty Detector ID for member account. Only needed if enable_detector is false. Always for targettign any enable detector"
+  description = "GuardDuty Detector ID for member account. Only needed if enable_detector is false. Used for targeting any previously enable detector"
   default    = ""
 }

--- a/_variables.tf
+++ b/_variables.tf
@@ -32,3 +32,8 @@ variable "enable_detector" {
   description = "Enable GuardDuty Member Detector"
   default     = true
 }
+
+variable "member_detector_id" {
+  description = "GuardDuty Detector ID for member account. Only needed if enable_detector is false. Always for targettign any enable detector"
+  default    = ""
+}

--- a/_variables.tf
+++ b/_variables.tf
@@ -27,3 +27,8 @@ variable "sns_email_arn" {
   type        = string
   default     = ""
 }
+
+variable "enable_detector" {
+  description = "Enable GuardDuty Member Detector"
+  default     = true
+}

--- a/_variables.tf
+++ b/_variables.tf
@@ -33,6 +33,11 @@ variable "enable_detector" {
   default     = true
 }
 
+variable "create_invite_accepter" {
+  description = "Create GuardDuty Member Invite Accepter. Not needed if already setup as part of an organization"
+  default     = true
+}
+
 variable "member_detector_id" {
   description = "GuardDuty Detector ID for member account. Only needed if enable_detector is false. Always for targettign any enable detector"
   default    = ""

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -1,10 +1,12 @@
 resource "aws_guardduty_detector" "member" {
   count = var.enable_detector ? 1 : 0
+
   enable = var.enable_detector
 }
 
 resource "aws_guardduty_invite_accepter" "member" {
-  # detector_id       = try(aws_guardduty_detector.member.id, var.member_detector_id)
-  detector_id       = var.member_detector_id
+  count = var.create_invite_accepter ? 1 : 0
+
+  detector_id       = try(aws_guardduty_detector.member.id, var.member_detector_id)
   master_account_id = var.admin_account_id
 }

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -7,6 +7,6 @@ resource "aws_guardduty_detector" "member" {
 resource "aws_guardduty_invite_accepter" "member" {
   count = var.create_invite_accepter ? 1 : 0
 
-  detector_id       = try(aws_guardduty_detector.member.id, var.member_detector_id)
+  detector_id       = try(aws_guardduty_detector.member[0].id, var.member_detector_id)
   master_account_id = var.admin_account_id
 }

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -3,6 +3,6 @@ resource "aws_guardduty_detector" "member" {
 }
 
 resource "aws_guardduty_invite_accepter" "member" {
-  detector_id       = try(aws_guardduty_detector.member.id, data.aws_guardduty_detector.member.id)
+  detector_id       = try(aws_guardduty_detector.member.id, var.member_detector_id)
   master_account_id = var.admin_account_id
 }

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -1,8 +1,10 @@
 resource "aws_guardduty_detector" "member" {
+  count = var.enable_detector ? 1 : 0
   enable = var.enable_detector
 }
 
 resource "aws_guardduty_invite_accepter" "member" {
-  detector_id       = try(aws_guardduty_detector.member.id, var.member_detector_id)
+  # detector_id       = try(aws_guardduty_detector.member.id, var.member_detector_id)
+  detector_id       = var.member_detector_id
   master_account_id = var.admin_account_id
 }

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -1,8 +1,8 @@
 resource "aws_guardduty_detector" "member" {
-  enable = true
+  enable = var.enable_detector
 }
 
 resource "aws_guardduty_invite_accepter" "member" {
-  detector_id       = aws_guardduty_detector.member.id
+  detector_id       = try(aws_guardduty_detector.member.id, data.aws_guardduty_detector.member.id)
   master_account_id = var.admin_account_id
 }


### PR DESCRIPTION
Allow for use of this module within AWS Organizations that already have guard duty enabled and are under management from a Security Hub admin account. 

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

Without the ability to disable the invite acceptor or the initial enablement of the detector itself then this module could never be used within an AWS setup that already has the Guard Duty enabled at the Organization level. 

The variables I introduced are none-breaking, in the sense that anyone using the module will not have to update definitions as the default is the same as the previous module version.

All the changes I have tested in my own AWS env which contains the situation I was solving for.